### PR TITLE
Account for logical newlines within statements

### DIFF
--- a/flake8_tuple.py
+++ b/flake8_tuple.py
@@ -102,13 +102,19 @@ def check_for_wrong_tuple(tree, code, noqa):
     if not candidates:
         return []
     for candidate in candidates:
+        number_nl = 0  # account for logical newlines within statements
         tokens = tokenize.generate_tokens(
             lambda L=iter(code): next(L)
         )
         previous_token = None
         for t in tokens:
+            if previous_token is not None and previous_token.type == tokenize.NEWLINE:
+                number_nl = 0
             x = TokenInfo(*t)
-            if x.start[0] != candidate[0]:
+            if x.type == tokenize.NL:
+                number_nl += 1
+            if x.start[0] - number_nl != candidate[0]:
+                previous_token = x
                 continue
             if x.type == token.NEWLINE and ending_of_bad_tuple(previous_token):
                 errors.append(x.start)

--- a/tests/test_pep8_tuple.py
+++ b/tests/test_pep8_tuple.py
@@ -29,6 +29,8 @@ class Testflake8Tuple(unittest.TestCase):
         ("base_url = reverse(\n'test',\nargs=pk,\n)", 0),
         ("group_by = function_call('arg'),", 1),
         ("group_by = ('foobar' * 3),", 1),
+        ("val = {}.get(1),", 1),
+        ("val = {}.get(\n1),", 1),
     )
     def test_tuple(self, code, errors):
         result = check_code_for_wrong_tuple(code)


### PR DESCRIPTION
This finds trailing commas in multiline assignments, e.g.

```
val = {}.get(
    1),
```

Also correct `previous_token` tracking during `continue`.