### PR TITLE
Fix reading from stdin after it was closed.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+0.2.14 (2019-03-12)
+-------------------
+* Fix reading from stdin when it is closed.
+
 0.2.13 (2016-07-25)
 -------------------
 * Fixed #14 - false negative

--- a/flake8_tuple.py
+++ b/flake8_tuple.py
@@ -10,7 +10,12 @@ try:
 except ImportError:
     import pep8
 
-__version__ = '0.2.13'
+try:
+    from flake8.engine import pep8 as stdin_utils
+except ImportError:
+    from flake8 import utils as stdin_utils
+
+__version__ = '0.2.14'
 
 
 ERROR_CODE = 'T801'
@@ -30,7 +35,7 @@ else:
 
 def get_lines(filename):
     if filename in ('stdin', '-', None):
-        return pep8.stdin_get_value().splitlines(True)
+        return stdin_utils.stdin_get_value().splitlines(True)
     else:
         return pep8.readlines(filename)
 


### PR DESCRIPTION
**Summary:** Couple of `flake8` plugins rely on [pycodestyle.stdin_get_value](https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py#L1762), which does not cache the string, after reading it from stdin and closing the buffer. This means that if there are two plugins using this function - the second plugin relying on this function, cannot read from stdin, because it was closed, and `ValueError: I/O operation on closed file` gets raised.

**Fix:** use [flake8.utils.stdin_get_value](https://github.com/PyCQA/flake8/blob/master/src/flake8/utils.py#L205), which caches the stdin, so that multiple plugins can use it. It is based on [flake8-commas](https://github.com/PyCQA/flake8-commas/blob/master/flake8_commas/_base.py#L10) that does not seem to have this issue.

**Steps to reproduce:**

`requirements.txt`:

```
flake8==3.7.6
flake8-tuple==0.2.13
flake8-print==3.1.0
```

Run:

```
python -m flake8 - < path/to/python/file.py
```

Expected output: lint successfully.
Actual output:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/__main__.py", line 4, in <module>
    cli.main()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 394, in run
    self._run(argv)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 382, in _run
    self.run_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 301, in run_checks
    self.file_checker_manager.run()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 330, in run
    self.run_serial()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 314, in run_serial
    checker.run_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 608, in run_checks
    self.run_ast_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 504, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8_tuple.py", line 48, in run
    lines = get_lines(self.filename)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8_tuple.py", line 33, in get_lines
    return pep8.stdin_get_value().splitlines(True)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/pycodestyle.py", line 1726, in stdin_get_value
    return TextIOWrapper(sys.stdin.buffer, errors='ignore').read()
ValueError: I/O operation on closed file
```

**Additional comments:**

In my environment this error got triggered in `flake8-print` and `flake8-tuple`. I am simultaneously doing a similar fix to [flake8-print](https://github.com/JBKahn/flake8-print/pull/36) as well. However, there must be a third plugin that uses `pycodestyle.stdin_get_value` first time. I will investigate and do a similar fix there as well.

I bumped version up as it would be great to release this fix quickly - it would save my eyes from emacs+flycheck blowing up with an error taking half the buffer on every file save. :)

Let me know if I can improve this to expedite the release.

Thank you.