### PR TITLE
Skip keyword argument assignments

### DIFF
--- a/flake8_tuple.py
+++ b/flake8_tuple.py
@@ -126,7 +126,7 @@ def check_for_wrong_tuple(tree, code, noqa):
                 number_nl += 1
             if x.type == token.NEWLINE and ending_of_bad_tuple(previous_token):
                 errors.append(x.start)
-            if x.type == token.OP and x.string == '=':
+            if x.type == token.OP and x.string == '=' and previous_token.type != token.NAME:
                 x = TokenInfo(*next(tokens))
                 if x.type != token.OP and x.string != '(':
                     x_next = TokenInfo(*next(tokens))

--- a/tests/test_pep8_tuple.py
+++ b/tests/test_pep8_tuple.py
@@ -30,6 +30,7 @@ class Testflake8Tuple(unittest.TestCase):
         ("base_url = reverse(\n'test',\nargs=(pk,)\n)", 0),
         ("base_url = reverse(\n'test',\nargs=pk,\n)", 0),
         ("group_by = function_call('arg'),", 1),
+        ("group_by = (function_call(True, a=None, b=None),)", 0),
         ("group_by = ('foobar' * 3),", 1),
         ("val = {}.get(1),", 1),
         ("val = {}.get(\n1),", 1),


### PR DESCRIPTION
We were previously hitting false positives on cases like this:

  group_by = (function_call(True, a=None, b=None),)

... because we knew we were inside of a single-element tuple and the
inner `=` token caused the keyword argument assignment to trigger our
error.

We now ignore assignment operators within single a known single-element
tuple because they will almost certainly be related to function calls.

Alternatively, we could look for and track function calls themselves,
but that approach would involve more complex nesting logic (because
function arguments values could be tuples themselves), so I opted for
this simpler (and hopefully still correct) heuristic.

Fixes #26 